### PR TITLE
fix: make `incomingCall` the canonical VoIP push key (accept `incoming_call`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ With custom ringtone and dialtone:
           "defaultDialtone": "dialtone.wav",
           "incomingCallTimeout": 45,
           "outgoingCallTimeout": 60,
+          "fulfillAnswerCallTimeout": 30,
           "microphonePermission": "$(PRODUCT_NAME) needs the microphone to make calls."
         }
       ]
@@ -158,7 +159,7 @@ Calls.addCallAnsweredListener(({ id }) => {
 });
 ```
 
-Both transports wrap the event under an `incomingCall` key, just at different layers — APNs in the push payload dictionary, FCM in the data block:
+Both transports wrap the event under an `incomingCall` key, just at different layers — APNs in the push payload dictionary, FCM in the data block. (The snake_case `incoming_call` is also accepted for backwards compatibility.)
 
 ### 🍎 iOS — APNs VoIP push
 

--- a/android/src/main/java/expo/modules/callkittelecom/models/CallModels.kt
+++ b/android/src/main/java/expo/modules/callkittelecom/models/CallModels.kt
@@ -62,7 +62,7 @@ data class CallParticipant(
  *
  * Two construction paths:
  * - [fromMap]: parses JS camelCase dictionaries (used by `reportIncomingCall`).
- * - [fromPayload]: parses a push payload that wraps the event under the top-level `incoming_call`
+ * - [fromPayload]: parses a push payload that wraps the event under the top-level `incomingCall`
  *   key (used by VoIP push handling).
  */
 data class IncomingCallEvent(
@@ -164,15 +164,17 @@ data class IncomingCallEvent(
         /**
          * Parses an `IncomingCallEvent` from a push payload.
          *
-         * The payload MUST wrap the event under the top-level key `incoming_call`. There is no
-         * fallback to a flat top-level shape. Inner keys are camelCase, matching the TS contract
-         * and the example server.
+         * The payload MUST wrap the event under the top-level key `incomingCall`; the snake_case
+         * `incoming_call` is also accepted for backwards compatibility. There is no fallback to a
+         * flat top-level shape. Inner keys are camelCase, matching the TS contract.
          *
          * Returns `null` if the envelope is missing or required fields are absent.
          */
         @Suppress("UNCHECKED_CAST")
         fun fromPayload(payload: Map<String, Any?>): IncomingCallEvent? {
-            val event = payload["incoming_call"] as? Map<String, Any?> ?: return null
+            val event =
+                (payload["incomingCall"] ?: payload["incoming_call"]) as? Map<String, Any?>
+                    ?: return null
 
             val eventId = event["eventId"] as? String ?: ""
             val serverCallId = event["serverCallId"] as? String ?: ""

--- a/android/src/main/java/expo/modules/callkittelecom/services/ExpoCallKitTelecomMessagingService.kt
+++ b/android/src/main/java/expo/modules/callkittelecom/services/ExpoCallKitTelecomMessagingService.kt
@@ -19,15 +19,17 @@ import org.json.JSONObject
  * by the existing notification delegate via [super], and call payloads are routed directly to
  * Telecom.
  *
- * Wire format (matches example/server/lib/fcm.ts): data["messageType"] = "incoming_call"
- * data["incoming_call"] = JSON string of the IncomingCallEvent (camelCase)
+ * Wire format (matches example/server/lib/fcm.ts): data["messageType"] = "incomingCall"
+ * data["incomingCall"] = JSON string of the IncomingCallEvent (camelCase). The snake_case envelope
+ * (messageType/key "incoming_call") is also accepted for backwards compatibility.
  */
 class ExpoCallKitTelecomMessagingService : ExpoFirebaseMessagingService() {
     companion object {
         private const val TAG = "ExpoCallKitTelecom.FCM"
         private const val KEY_MESSAGE_TYPE = "messageType"
-        private const val MESSAGE_TYPE_INCOMING_CALL = "incoming_call"
-        private const val KEY_INCOMING_CALL = "incoming_call"
+        // Canonical camelCase envelope plus the snake_case form accepted for backwards compatibility.
+        private val MESSAGE_TYPE_INCOMING_CALL = setOf("incomingCall", "incoming_call")
+        private val KEYS_INCOMING_CALL = listOf("incomingCall", "incoming_call")
         private const val DEDUP_WINDOW_MS = 120_000L
 
         private val dedupeLock = Any()
@@ -65,8 +67,8 @@ class ExpoCallKitTelecomMessagingService : ExpoFirebaseMessagingService() {
         try {
             CallManager.shared.initialize(applicationContext)
 
-            // Wrap under the envelope so we go through the same parser path as iOS.
-            val event = IncomingCallEvent.fromPayload(mapOf(KEY_INCOMING_CALL to eventMap))
+            // Wrap under the canonical envelope so we go through the same parser path as iOS.
+            val event = IncomingCallEvent.fromPayload(mapOf("incomingCall" to eventMap))
             if (event == null) {
                 Log.w(TAG, "Failed to validate incoming call event from FCM payload")
                 return
@@ -82,11 +84,11 @@ class ExpoCallKitTelecomMessagingService : ExpoFirebaseMessagingService() {
     }
 
     private fun parseIncomingCallEvent(data: Map<String, String>): Map<String, Any?>? {
-        if (data[KEY_MESSAGE_TYPE] != MESSAGE_TYPE_INCOMING_CALL) {
+        if (data[KEY_MESSAGE_TYPE] !in MESSAGE_TYPE_INCOMING_CALL) {
             return null
         }
 
-        val nestedPayload = data[KEY_INCOMING_CALL] ?: return null
+        val nestedPayload = KEYS_INCOMING_CALL.firstNotNullOfOrNull { data[it] } ?: return null
         return try {
             jsonObjectToMap(JSONObject(nestedPayload))
         } catch (error: Throwable) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,7 @@ With custom ringtone and dialtone:
           "defaultDialtone": "dialtone.wav",
           "incomingCallTimeout": 45,
           "outgoingCallTimeout": 60,
+          "fulfillAnswerCallTimeout": 30,
           "microphonePermission": "$(PRODUCT_NAME) needs the microphone to make calls."
         }
       ]

--- a/docs/voip-push.md
+++ b/docs/voip-push.md
@@ -40,7 +40,7 @@ Calls.addCallAnsweredListener(({ id }) => {
 });
 ```
 
-Both transports wrap the event under an `incomingCall` key, just at different layers — APNs in the push payload dictionary, FCM in the data block.
+Both transports wrap the event under an `incomingCall` key, just at different layers — APNs in the push payload dictionary, FCM in the data block. (The snake_case `incoming_call` is also accepted for backwards compatibility.)
 
 ## iOS — APNs VoIP push
 

--- a/example/server/lib/apns.ts
+++ b/example/server/lib/apns.ts
@@ -37,7 +37,7 @@ export async function sendApns(
   const host = config.production
     ? "api.push.apple.com"
     : "api.sandbox.push.apple.com";
-  const body = JSON.stringify({ incoming_call: event });
+  const body = JSON.stringify({ incomingCall: event });
 
   const client = http2Connect(`https://${host}`);
   try {

--- a/example/server/lib/fcm.ts
+++ b/example/server/lib/fcm.ts
@@ -75,8 +75,8 @@ export async function sendFcm(
         message: {
           token: config.deviceToken,
           data: {
-            messageType: "incoming_call",
-            incoming_call: JSON.stringify(event),
+            messageType: "incomingCall",
+            incomingCall: JSON.stringify(event),
           },
           android: { priority: "HIGH" },
         },

--- a/ios/Managers/VoIPPushManager+PKPushRegistryDelegate.swift
+++ b/ios/Managers/VoIPPushManager+PKPushRegistryDelegate.swift
@@ -40,7 +40,7 @@ extension VoIPPushManager: PKPushRegistryDelegate {
   ///
   /// This method MUST report a call to CallKit before returning, per Apple's requirements.
   /// The payload is expected to wrap an `IncomingCallEvent` under the top-level
-  /// key `"incoming_call"`, matching `IncomingCallEventParser`.
+  /// key `"incomingCall"`, matching `IncomingCallEventParser`.
   ///
   /// - Parameters:
   ///   - registry: The push registry.

--- a/ios/Models/IncomingCallEvent.swift
+++ b/ios/Models/IncomingCallEvent.swift
@@ -132,12 +132,15 @@ struct IncomingCallEventRecord: Record {
 
 /// Parses an `IncomingCallEvent` from a VoIP push payload.
 ///
-/// The payload must wrap the event under the top-level key `"incoming_call"`.
-/// There is no fallback to a flat top-level shape. Inner keys are camelCase
-/// to match the TS contract and the example server's wire format.
+/// The payload must wrap the event under the top-level key `"incomingCall"`.
+/// The snake_case `"incoming_call"` is also accepted for backwards compatibility.
+/// There is no fallback to a flat top-level shape. Inner keys are camelCase to
+/// match the TS contract.
 enum IncomingCallEventParser {
   static func parse(from payload: [AnyHashable: Any]) -> IncomingCallEvent? {
-    guard let event = payload["incoming_call"] as? [AnyHashable: Any] else {
+    guard
+      let event = (payload["incomingCall"] ?? payload["incoming_call"]) as? [AnyHashable: Any]
+    else {
       return nil
     }
 


### PR DESCRIPTION
## Problem

The README and docs documented the VoIP push envelope key as `incomingCall` (camelCase):

```jsonc
{ "incomingCall": { /* IncomingCallEvent */ } }
```

…but the native parsers and the example server actually used `incoming_call` (snake_case). A push following the documented shape was silently dropped as a non-call notification — costing users real debugging time.

Fixes #15.

### Root cause

The *inner* event fields are genuinely camelCase (`eventId`, `serverCallId`, …), and the README even states "All keys are camelCase." When the prose/examples were polished, the **envelope** key got camelCased to match — but the parsers and example server (which weren't touched) kept emitting/reading snake_case. The docs drifted from the code.

## Fix

Make **`incomingCall` canonical everywhere**, and accept **`incoming_call` as a backwards-compatible fallback** so existing integrations keep working:

- **iOS** (`IncomingCallEventParser`) — reads `incomingCall ?? incoming_call`.
- **Android** (`IncomingCallEvent.fromPayload`) — reads `incomingCall ?: incoming_call`.
- **Android FCM service** — `messageType` and the data key both accept either form.
- **Example server** (`apns.ts`, `fcm.ts`) — now emits `incomingCall`, so the reference implementation matches the canonical docs (no more drift).
- **Docs** (`README.md`, `docs/voip-push.md`) — show `incomingCall` as canonical with a note that `incoming_call` is still accepted.

Chose camelCase as canonical (over standardizing on snake_case) because the payload is produced by JS/TS backends where camelCase is idiomatic and it matches the inner event fields; the snake_case shim can be deprecated later.

## Also

Documented the previously-undocumented `fulfillAnswerCallTimeout` plugin option (default 30s) in the config examples.