### PR TITLE
docs: document required peer dependencies in Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Tested end-to-end on real devices via the runnable `example/` app. Full compatib
 bun add expo-callkit-telecom
 ```
 
+This package declares `@livekit/react-native-webrtc` and `expo-notifications` as peer dependencies — install them alongside it:
+
+```sh
+bun add @livekit/react-native-webrtc expo-notifications
+```
+
+> If your app already depends on plain `react-native-webrtc`, replace it with `@livekit/react-native-webrtc`. They expose the same native module surface and can't coexist — having both installed will fail at `pod install` with a missing/duplicate pod error.
+
 Add the config plugin to `app.json` / `app.config.ts`. Minimal form:
 
 ```jsonc

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,14 @@ This library has been exercised end-to-end on real devices in the `example/` app
 bun add expo-callkit-telecom
 ```
 
+This package declares `@livekit/react-native-webrtc` and `expo-notifications` as peer dependencies — install them alongside it:
+
+```sh
+bun add @livekit/react-native-webrtc expo-notifications
+```
+
+> If your app already depends on plain `react-native-webrtc`, replace it with `@livekit/react-native-webrtc`. They expose the same native module surface and can't coexist — having both installed will fail at `pod install` with a missing/duplicate pod error.
+
 Add the config plugin to `app.json` / `app.config.ts`. Minimal form:
 
 ```jsonc


### PR DESCRIPTION
`package.json` already declares `@livekit/react-native-webrtc` and `expo-notifications` as peer dependencies, but the Install section in both README.md and docs/getting-started.md never mentions them.

#14 reported a `pod install` failure caused by having plain `react-native-webrtc` installed instead of `@livekit/react-native-webrtc` — they share the same native module surface and can't coexist. A follow-up comment confirmed `expo-notifications` is also required on Android and undocumented.

This adds one install command and one clarifying note to the Install section of both docs.

Fixes #14