### PR TITLE
Fix/invalid call fallback ends wrong session

### DIFF
--- a/docs/voip-push.md
+++ b/docs/voip-push.md
@@ -66,3 +66,18 @@ FCM data values must be strings, so JSON-encode the inner event and put it under
 ```
 
 Non-`incomingCall` data messages are forwarded to [`expo-notifications`](https://docs.expo.dev/versions/latest/sdk/notifications/)'s service for normal handling.
+
+## When the payload doesn't parse (iOS)
+
+Apple requires reporting a call to CallKit for **every** VoIP push, so a payload that fails
+validation still produces a brief system call UI ("Invalid Call") that the module ends
+immediately. No session is created and **no JS events are emitted** for it — from your app's
+perspective the push is silent.
+
+To find out why a payload was rejected, check the device log: the parser logs which guard
+failed (missing envelope, envelope of the wrong type — e.g. the FCM JSON-string form sent to
+APNs — missing/empty `eventId`/`serverCallId`, or a missing `caller.id`). In Console.app,
+filter on subsystem `expo-callkit-telecom`, category `VoIPPush`. You can reproduce rejection
+cases with `example/server/send-test-push.ts --raw-payload '<json>'`.
+
+On Android, an FCM message that fails validation falls through to `expo-notifications`.

--- a/example/server/lib/apns.ts
+++ b/example/server/lib/apns.ts
@@ -11,6 +11,10 @@ export interface ApnsConfig {
   topic: string;
   deviceToken: string;
   production?: boolean;
+  /** Verbatim APNs body override — bypasses the `{ incomingCall: event }`
+   * wrapper so malformed payloads can exercise the native parser's
+   * rejection paths. When set, `event` is ignored. */
+  rawBody?: string;
 }
 
 function b64url(input: string | Buffer): string {
@@ -37,7 +41,7 @@ export async function sendApns(
   const host = config.production
     ? "api.push.apple.com"
     : "api.sandbox.push.apple.com";
-  const body = JSON.stringify({ incomingCall: event });
+  const body = config.rawBody ?? JSON.stringify({ incomingCall: event });
 
   const client = http2Connect(`https://${host}`);
   try {

--- a/example/server/send-test-push.ts
+++ b/example/server/send-test-push.ts
@@ -17,6 +17,10 @@
  *   bun send-test-push.ts --metadata '{"declineToken":"abc"}'   # JSON object; rides into
  *                                                               # the killed-app call-ended
  *                                                               # broadcast on Android
+ *   bun send-test-push.ts --raw-payload '{"notACall":{}}'       # iOS only: send this JSON
+ *                                                               # verbatim as the APNs body —
+ *                                                               # exercises the native parser's
+ *                                                               # rejection paths
  *   bun send-test-push.ts --production     # iOS prod APNs (default: sandbox)
  *
  * Required env (.env auto-loaded by bun):
@@ -82,7 +86,24 @@ const forceIos = flag("--ios");
 const forceAndroid = flag("--android");
 const usePrd = flag("--production");
 
+const rawPayload = arg("--raw-payload");
+if (rawPayload !== undefined) {
+  try {
+    JSON.parse(rawPayload);
+  } catch (e) {
+    throw new Error(`--raw-payload is not valid JSON (${(e as Error).message}), got: ${rawPayload}`);
+  }
+  if (forceAndroid) {
+    // FCM wraps the event differently (data message); a verbatim-body override
+    // is only meaningful for the APNs path.
+    throw new Error("--raw-payload is iOS-only; drop --android");
+  }
+}
+
 const want = (target: "ios" | "android") => {
+  // --raw-payload is an APNs-body override; never fan out a normal FCM push
+  // alongside it.
+  if (rawPayload !== undefined) return target === "ios";
   if (forceIos) return target === "ios";
   if (forceAndroid) return target === "android";
   return target === "ios"
@@ -99,6 +120,7 @@ async function runApns(): Promise<void> {
     topic: `${env.BUNDLE_ID}.voip`,
     deviceToken: env.APNS_DEVICE_TOKEN,
     production: usePrd,
+    rawBody: rawPayload,
   });
 }
 

--- a/ios/Managers/CallManager+CXProviderDelegate.swift
+++ b/ios/Managers/CallManager+CXProviderDelegate.swift
@@ -58,6 +58,17 @@ extension CallManager: CXProviderDelegate {
   func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
     Log.call.debug("CXAnswerCallAction - id: \(action.callUUID)")
 
+    // An invalid-payload placeholder (reported and immediately ended) can
+    // still receive a fast answer in its display window. There is no session
+    // and never will be — fail fast instead of creating a fulfill request that
+    // times out in 30s and emitting a CallAnswered event for an id JS has
+    // never seen.
+    guard !isInvalidCallId(action.callUUID) else {
+      Log.call.debug("CXAnswerCallAction for invalid-payload placeholder - id: \(action.callUUID)")
+      action.fail()
+      return
+    }
+
     // Cancel the incoming call timeout since user answered
     cancelCallTimeout(for: action.callUUID)
 
@@ -98,6 +109,15 @@ extension CallManager: CXProviderDelegate {
 
   func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
     Log.call.debug("CXEndCallAction - id: \(action.callUUID)")
+
+    // A decline aimed at an invalid-payload placeholder must not reach the
+    // real-call teardown below — DialtonePlayer is process-wide, so stopping
+    // it here would silence a concurrently ringing outgoing call.
+    guard !isInvalidCallId(action.callUUID) else {
+      Log.call.debug("CXEndCallAction for invalid-payload placeholder - id: \(action.callUUID)")
+      action.fulfill()
+      return
+    }
 
     // Stop dialtone and cancel timeout
     DialtonePlayer.shared.stop()

--- a/ios/Managers/CallManager.swift
+++ b/ios/Managers/CallManager.swift
@@ -53,6 +53,31 @@ class CallManager: NSObject {
   /// Lock for thread-safe access to call timeout tasks.
   private let timeoutTasksLock = NSLock()
 
+  /// CallKit UUIDs of invalid-payload placeholder calls (see
+  /// `reportAndEndInvalidCall`). CallKit can deliver user actions for a
+  /// placeholder in the window between its report and its end; the action
+  /// handlers must not route those through real-call state (fulfill requests,
+  /// JS events, the process-wide dialtone). Entries are never pruned — 16
+  /// bytes each, bounded by malformed pushes per process lifetime.
+  private var invalidCallIds = Set<UUID>()
+
+  /// Lock for thread-safe access to invalid call IDs.
+  private let invalidCallIdsLock = NSLock()
+
+  /// Marks a CallKit UUID as an invalid-payload placeholder (thread-safe).
+  func markInvalidCallId(_ id: UUID) {
+    invalidCallIdsLock.lock()
+    defer { invalidCallIdsLock.unlock() }
+    invalidCallIds.insert(id)
+  }
+
+  /// Whether a CallKit UUID is an invalid-payload placeholder (thread-safe).
+  func isInvalidCallId(_ id: UUID) -> Bool {
+    invalidCallIdsLock.lock()
+    defer { invalidCallIdsLock.unlock() }
+    return invalidCallIds.contains(id)
+  }
+
   private override init() {
     let configuration = CXProviderConfiguration()
     configuration.supportsVideo = true
@@ -433,6 +458,11 @@ class CallManager: NSObject {
   func reportAndEndInvalidCall(completion: @escaping () -> Void) {
     let id = UUID()
     Log.call.debug("Reporting invalid-payload placeholder call - id: \(id)")
+
+    // Marked BEFORE the report so an answer/decline delivered in the window
+    // between display and the .failed report below is recognized and rejected
+    // by the action handlers instead of touching real-call state.
+    markInvalidCallId(id)
 
     let update = CXCallUpdate()
     update.hasVideo = false

--- a/ios/Managers/CallManager.swift
+++ b/ios/Managers/CallManager.swift
@@ -355,7 +355,11 @@ class CallManager: NSObject {
   /// - Parameters:
   ///   - event: The incoming call event containing caller info.
   ///   - completion: Called when the CallKit report completes (success or failure).
-  func reportIncomingCall(event: IncomingCallEvent, completion: @escaping (Error?) -> Void) {
+  ///     Receives the CallKit UUID assigned to this call, so the caller can end
+  ///     EXACTLY this session later. Ending `store.firstSession` instead ended the
+  ///     wrong session whenever another call (e.g. the user's own outgoing call)
+  ///     was already active — the reported call then rang forever.
+  func reportIncomingCall(event: IncomingCallEvent, completion: @escaping (UUID, Error?) -> Void) {
     let id = UUID()
     Log.call.debug("Reporting incoming call (sync) - id: \(id)")
 
@@ -400,7 +404,7 @@ class CallManager: NSObject {
           "Failed to report incoming call to CallKit - id: \(id), error: \(error.localizedDescription)"
         )
         AudioManager.shared.restoreAudioSession()
-        completion(error)
+        completion(id, error)
         return
       }
 
@@ -417,7 +421,7 @@ class CallManager: NSObject {
         self?.startCallTimeout(for: id, timeout: Self.incomingCallTimeout)
       }
 
-      completion(nil)
+      completion(id, nil)
     }
   }
 

--- a/ios/Managers/CallManager.swift
+++ b/ios/Managers/CallManager.swift
@@ -355,11 +355,7 @@ class CallManager: NSObject {
   /// - Parameters:
   ///   - event: The incoming call event containing caller info.
   ///   - completion: Called when the CallKit report completes (success or failure).
-  ///     Receives the CallKit UUID assigned to this call, so the caller can end
-  ///     EXACTLY this session later. Ending `store.firstSession` instead ended the
-  ///     wrong session whenever another call (e.g. the user's own outgoing call)
-  ///     was already active — the reported call then rang forever.
-  func reportIncomingCall(event: IncomingCallEvent, completion: @escaping (UUID, Error?) -> Void) {
+  func reportIncomingCall(event: IncomingCallEvent, completion: @escaping (Error?) -> Void) {
     let id = UUID()
     Log.call.debug("Reporting incoming call (sync) - id: \(id)")
 
@@ -404,7 +400,7 @@ class CallManager: NSObject {
           "Failed to report incoming call to CallKit - id: \(id), error: \(error.localizedDescription)"
         )
         AudioManager.shared.restoreAudioSession()
-        completion(id, error)
+        completion(error)
         return
       }
 
@@ -421,7 +417,39 @@ class CallManager: NSObject {
         self?.startCallTimeout(for: id, timeout: Self.incomingCallTimeout)
       }
 
-      completion(id, nil)
+      completion(nil)
+    }
+  }
+
+  /// Reports the placeholder call PushKit requires for an unparseable payload
+  /// and immediately ends it.
+  ///
+  /// Deliberately bypasses the session machinery: no `CallSession` is stored,
+  /// no timeout is armed, no JS events are emitted, and the audio session is
+  /// not touched — there is nothing here to connect. `provider.reportCall`
+  /// needs no session lookup to dismiss the CallKit UI.
+  ///
+  /// - Parameter completion: Called after CallKit has processed the report.
+  func reportAndEndInvalidCall(completion: @escaping () -> Void) {
+    let id = UUID()
+    Log.call.debug("Reporting invalid-payload placeholder call - id: \(id)")
+
+    let update = CXCallUpdate()
+    update.hasVideo = false
+    update.remoteHandle = CXHandle(type: .generic, value: "invalid")
+    update.localizedCallerName = "Invalid Call"
+
+    provider.reportNewIncomingCall(with: id, update: update) { [weak self] error in
+      if let error = error {
+        // CallKit disallowed the call: it was never displayed, so per the
+        // CXProvider contract we must not proceed with it — nothing to end.
+        Log.call.error(
+          "Failed to report invalid-payload call - id: \(id), error: \(error.localizedDescription)"
+        )
+      } else {
+        self?.provider.reportCall(with: id, endedAt: Date(), reason: .failed)
+      }
+      completion()
     }
   }
 

--- a/ios/Managers/VoIPPushManager+PKPushRegistryDelegate.swift
+++ b/ios/Managers/VoIPPushManager+PKPushRegistryDelegate.swift
@@ -63,7 +63,20 @@ extension VoIPPushManager: PKPushRegistryDelegate {
     Log.voipPush.debug("Received VoIP push - payload keys: \(dictionaryPayload.keys)")
 
     guard let event = IncomingCallEventParser.parse(from: dictionaryPayload) else {
-      Log.voipPush.error("Failed to parse VoIP push payload as IncomingCallEvent")
+      // Say WHICH parse guard failed — GUIDs only, no display names, so this is
+      // safe to log and enough to identify the offending payload shape.
+      let inner = (dictionaryPayload["incomingCall"] ?? dictionaryPayload["incoming_call"])
+        as? [AnyHashable: Any]
+      let callerId = (inner?["caller"] as? [AnyHashable: Any])?["id"] as? String
+      Log.voipPush.error(
+        """
+        Failed to parse VoIP push payload as IncomingCallEvent - \
+        wrapper: \(inner != nil), \
+        eventId: \(inner?["eventId"] as? String ?? "<missing>"), \
+        serverCallId: \(inner?["serverCallId"] as? String ?? "<missing>"), \
+        callerId: \(callerId ?? "<missing>")
+        """
+      )
       // We must still report a call to CallKit even on parse failure, or the
       // app will be terminated.
       reportFailedIncomingCall(completion: completion)
@@ -76,7 +89,7 @@ extension VoIPPushManager: PKPushRegistryDelegate {
 
     // Report the incoming call to CallKit using callback-based API
     // (async/await may not work reliably when app is launched from terminated state)
-    CallManager.shared.reportIncomingCall(event: event) { error in
+    CallManager.shared.reportIncomingCall(event: event) { _, error in
       if let error = error {
         Log.voipPush.error("Failed to report incoming call: \(error.localizedDescription)")
       } else {
@@ -106,16 +119,22 @@ extension VoIPPushManager: PKPushRegistryDelegate {
       metadata: nil
     )
 
-    // Use callback-based API for reliability when app is launched from terminated state
-    CallManager.shared.reportIncomingCall(event: fallbackEvent) { error in
+    // Use callback-based API for reliability when app is launched from terminated state.
+    // End the fallback session by ITS OWN id (delivered via the completion):
+    // ending `firstSession` here ended the WRONG session whenever another call
+    // was already active (the user's own outgoing call got reported ended while
+    // the "Invalid Call" rang on), and when no session existed yet it raced the
+    // store add and ended nothing.
+    CallManager.shared.reportIncomingCall(event: fallbackEvent) { id, error in
       if let error = error {
         Log.voipPush.error("Failed to report fallback incoming call: \(error.localizedDescription)")
       }
       // Immediately end the call since it's invalid
       Task {
-        if let session = await CallManager.shared.store.firstSession {
-          await CallManager.shared.reportCallEnded(for: session.id, reason: .failed)
-        }
+        // Dismisses the CallKit UI by id (no store dependency), then sweeps the
+        // store in case the report path's async add landed after the removal.
+        await CallManager.shared.reportCallEnded(for: id, reason: .failed)
+        await CallManager.shared.store.remove(for: id)
       }
       completion()
     }

--- a/ios/Managers/VoIPPushManager+PKPushRegistryDelegate.swift
+++ b/ios/Managers/VoIPPushManager+PKPushRegistryDelegate.swift
@@ -63,23 +63,10 @@ extension VoIPPushManager: PKPushRegistryDelegate {
     Log.voipPush.debug("Received VoIP push - payload keys: \(dictionaryPayload.keys)")
 
     guard let event = IncomingCallEventParser.parse(from: dictionaryPayload) else {
-      // Say WHICH parse guard failed — GUIDs only, no display names, so this is
-      // safe to log and enough to identify the offending payload shape.
-      let inner = (dictionaryPayload["incomingCall"] ?? dictionaryPayload["incoming_call"])
-        as? [AnyHashable: Any]
-      let callerId = (inner?["caller"] as? [AnyHashable: Any])?["id"] as? String
-      Log.voipPush.error(
-        """
-        Failed to parse VoIP push payload as IncomingCallEvent - \
-        wrapper: \(inner != nil), \
-        eventId: \(inner?["eventId"] as? String ?? "<missing>"), \
-        serverCallId: \(inner?["serverCallId"] as? String ?? "<missing>"), \
-        callerId: \(callerId ?? "<missing>")
-        """
-      )
-      // We must still report a call to CallKit even on parse failure, or the
-      // app will be terminated.
-      reportFailedIncomingCall(completion: completion)
+      // The parser logs which guard rejected the payload. We must still report
+      // a call to CallKit even on parse failure, or the app will be terminated.
+      Log.voipPush.error("Failed to parse VoIP push payload as IncomingCallEvent")
+      CallManager.shared.reportAndEndInvalidCall(completion: completion)
       return
     }
 
@@ -89,52 +76,11 @@ extension VoIPPushManager: PKPushRegistryDelegate {
 
     // Report the incoming call to CallKit using callback-based API
     // (async/await may not work reliably when app is launched from terminated state)
-    CallManager.shared.reportIncomingCall(event: event) { _, error in
+    CallManager.shared.reportIncomingCall(event: event) { error in
       if let error = error {
         Log.voipPush.error("Failed to report incoming call: \(error.localizedDescription)")
       } else {
         Log.voipPush.debug("Successfully reported incoming call from VoIP push")
-      }
-      completion()
-    }
-  }
-
-  /// Reports a failed incoming call to CallKit when we can't parse the push payload.
-  ///
-  /// Per Apple's requirements, we must report a call to CallKit when receiving a VoIP push.
-  /// If we can't parse the payload, we report a call and immediately end it.
-  private nonisolated func reportFailedIncomingCall(completion: @escaping () -> Void) {
-    let fallbackEvent = IncomingCallEvent(
-      eventId: UUID().uuidString.lowercased(),
-      serverCallId: UUID().uuidString.lowercased(),
-      caller: IncomingCallEvent.Caller(
-        id: UUID().uuidString,
-        displayName: "Invalid Call",
-        avatarUrl: nil,
-        phoneNumber: nil,
-        email: nil
-      ),
-      hasVideo: false,
-      startedAt: Date(),
-      metadata: nil
-    )
-
-    // Use callback-based API for reliability when app is launched from terminated state.
-    // End the fallback session by ITS OWN id (delivered via the completion):
-    // ending `firstSession` here ended the WRONG session whenever another call
-    // was already active (the user's own outgoing call got reported ended while
-    // the "Invalid Call" rang on), and when no session existed yet it raced the
-    // store add and ended nothing.
-    CallManager.shared.reportIncomingCall(event: fallbackEvent) { id, error in
-      if let error = error {
-        Log.voipPush.error("Failed to report fallback incoming call: \(error.localizedDescription)")
-      }
-      // Immediately end the call since it's invalid
-      Task {
-        // Dismisses the CallKit UI by id (no store dependency), then sweeps the
-        // store in case the report path's async add landed after the removal.
-        await CallManager.shared.reportCallEnded(for: id, reason: .failed)
-        await CallManager.shared.store.remove(for: id)
       }
       completion()
     }

--- a/ios/Models/IncomingCallEvent.swift
+++ b/ios/Models/IncomingCallEvent.swift
@@ -141,12 +141,23 @@ enum IncomingCallEventParser {
     guard
       let event = (payload["incomingCall"] ?? payload["incoming_call"]) as? [AnyHashable: Any]
     else {
+      Log.voipPush.error(
+        "Push payload has no parseable incomingCall envelope - top-level keys: \(payload.keys)"
+      )
       return nil
     }
+    // Which envelope key matched: "incomingCall" is canonical, "incoming_call"
+    // is back-compat — an integrator debugging a malformed push wants to know.
+    let envelopeKey =
+      payload["incomingCall"] is [AnyHashable: Any] ? "incomingCall" : "incoming_call"
 
     let eventId = event["eventId"] as? String ?? ""
     let serverCallId = event["serverCallId"] as? String ?? ""
     guard !eventId.isEmpty, !serverCallId.isEmpty else {
+      Log.voipPush.error(
+        "Envelope '\(envelopeKey)' rejected - eventId: \(describe(event["eventId"])), "
+          + "serverCallId: \(describe(event["serverCallId"]))"
+      )
       return nil
     }
 
@@ -154,6 +165,11 @@ enum IncomingCallEventParser {
       let callerId = callerDict["id"] as? String,
       !callerId.isEmpty
     else {
+      let rawCallerId = (event["caller"] as? [AnyHashable: Any])?["id"]
+      Log.voipPush.error(
+        "Envelope '\(envelopeKey)' rejected - caller present: \(event["caller"] != nil), "
+          + "caller.id: \(describe(rawCallerId))"
+      )
       return nil
     }
     let caller = IncomingCallEvent.Caller(
@@ -183,6 +199,16 @@ enum IncomingCallEventParser {
       startedAt: startedAt,
       metadata: metadata
     )
+  }
+
+  /// Renders a rejected payload value for diagnostics. Quoted so an empty
+  /// string (rejected by the guards) is distinguishable from a missing key,
+  /// and length-capped because a value that just failed validation cannot be
+  /// assumed to be a well-formed identifier.
+  private static func describe(_ value: Any?) -> String {
+    guard let value = value else { return "<missing>" }
+    guard let string = value as? String else { return "<non-string>" }
+    return "\"\(string.prefix(64))\""
   }
 
   /// Parses an RFC 3339 timestamp. Handles optional fractional seconds.

--- a/ios/Models/IncomingCallEvent.swift
+++ b/ios/Models/IncomingCallEvent.swift
@@ -141,9 +141,18 @@ enum IncomingCallEventParser {
     guard
       let event = (payload["incomingCall"] ?? payload["incoming_call"]) as? [AnyHashable: Any]
     else {
-      Log.voipPush.error(
-        "Push payload has no parseable incomingCall envelope - top-level keys: \(payload.keys)"
-      )
+      if let raw = payload["incomingCall"] ?? payload["incoming_call"] {
+        // Wrong type. Most commonly the FCM wire form — a JSON-encoded STRING —
+        // sent to APNs, which expects a nested object.
+        Log.voipPush.error(
+          "incomingCall envelope has unexpected type \(type(of: raw)) - expected an object "
+            + "(sending the FCM JSON-string form to APNs?)"
+        )
+      } else {
+        Log.voipPush.error(
+          "Push payload has no incomingCall envelope - top-level keys: \(payload.keys)"
+        )
+      }
       return nil
     }
     // Which envelope key matched: "incomingCall" is canonical, "incoming_call"
@@ -167,7 +176,7 @@ enum IncomingCallEventParser {
     else {
       let rawCallerId = (event["caller"] as? [AnyHashable: Any])?["id"]
       Log.voipPush.error(
-        "Envelope '\(envelopeKey)' rejected - caller present: \(event["caller"] != nil), "
+        "Envelope '\(envelopeKey)' rejected - caller: \(describeCaller(event["caller"])), "
           + "caller.id: \(describe(rawCallerId))"
       )
       return nil
@@ -203,12 +212,24 @@ enum IncomingCallEventParser {
 
   /// Renders a rejected payload value for diagnostics. Quoted so an empty
   /// string (rejected by the guards) is distinguishable from a missing key,
-  /// and length-capped because a value that just failed validation cannot be
-  /// assumed to be a well-formed identifier.
+  /// length-capped, and escaped (`String(reflecting:)`) because a value that
+  /// just failed validation cannot be assumed to be a well-formed identifier —
+  /// unescaped quotes or newlines could forge fields or lines in the log
+  /// record. Cap first: the cap bounds retention, escaping bounds growth.
   private static func describe(_ value: Any?) -> String {
     guard let value = value else { return "<missing>" }
+    if value is NSNull { return "<null>" }
     guard let string = value as? String else { return "<non-string>" }
-    return "\"\(string.prefix(64))\""
+    return String(reflecting: String(string.prefix(64)))
+  }
+
+  /// Renders the caller container for diagnostics: an absent, JSON-null, or
+  /// wrongly-typed caller must each read differently from an object that is
+  /// merely missing its `id`.
+  private static func describeCaller(_ value: Any?) -> String {
+    guard let value = value else { return "<missing>" }
+    if value is NSNull { return "<null>" }
+    return value is [AnyHashable: Any] ? "object" : "<non-object: \(type(of: value))>"
   }
 
   /// Parses an RFC 3339 timestamp. Handles optional fractional seconds.


### PR DESCRIPTION
## Problem

When a VoIP push payload fails `IncomingCallEventParser.parse`, the library reports a fallback "Invalid Call" to CallKit (as Apple requires) and immediately tries to end it — via `store.firstSession`. That is insertion-order-first, with two user-visible failure modes:

- **Another session is already active** (e.g. the user's own outgoing call): the fallback ends *that* call's CallKit session, while the "Invalid Call" keeps ringing until the incoming-call timeout. A malformed push can effectively drop a user's active call — even when CallKit rejects the fallback report, the old code still ran the teardown.
- **No session exists yet**: `reportIncomingCall`'s `store.add` runs in a detached `Task` after the completion fires, so `firstSession` reads nil and nothing is ended at all.

The old path also routed the placeholder through the real-call machinery: it reconfigured a live call's audio session (`prepareAudioSessionForCall`), stored a session + armed a 45s timeout per malformed push, and on cold start its `IncomingCallReportedEvent` could evict a real call's queued event (the event queue keeps only the newest).

## Fix

The fallback gets its own path, `CallManager.reportAndEndInvalidCall(completion:)`: `reportNewIncomingCall` followed by `provider.reportCall(.failed)` in the same callback. No `CallSession`, no timeout, no JS events, no audio-session churn — the races disappear by construction. When CallKit disallows the report, nothing is ended, per the `CXProvider` contract. `reportIncomingCall(event:completion:)` is unchanged.

Because CallKit can still deliver user actions for the placeholder in its brief display window, the Answer/End handlers recognize placeholder UUIDs and fail/fulfill fast — a phantom answer previously created a fulfill request that timed out after 30s while emitting a `CallAnswered` event for an id JS never saw, and a phantom decline stopped the process-wide dialtone under a concurrently ringing outgoing call.

**Consumer-visible change:** an unparseable push no longer emits any JS events (`IncomingCallReported` / `CallSessionAdded` / `CallSessionRemoved` for the bogus call). This matches Android's silent fall-through and removes ghost sessions from `getActiveCallSession()`.

## Diagnostics

`IncomingCallEventParser` logs which guard rejected a payload, at the source: missing envelope (top-level keys) vs wrongly-typed envelope (naming the common mistake — the FCM JSON-string form sent to APNs), which envelope key matched (`incomingCall` canonical vs `incoming_call` back-compat), quoted + escaped + length-capped id values (empty ≠ missing ≠ non-string ≠ JSON null), and the caller container's type. Values are escaped (`String(reflecting:)`) so a value that failed validation cannot forge log fields. Identifiers only — display names and metadata are never logged. Documented in `docs/voip-push.md` (subsystem `expo-callkit-telecom`, category `VoIPPush`).

## Testability

`example/server/send-test-push.ts --raw-payload '<json>'` sends an arbitrary APNs body verbatim (iOS-only, suppresses FCM fan-out) — previously none of the rejection paths was reachable through `buildEvent`'s defaults. Suggested manual matrix: one payload per guard; a malformed push during a connected call and during a ringing call (the live call must survive — the core regression); cold-start real+malformed push (the real call's event must reach JS); fast Answer/Decline on the placeholder (no 30s stall, ringback unaffected).

## Notes for the maintainer

- Android parity: `IncomingCallEvent.fromPayload` has the same guards but logs one generic line — happy to mirror the diagnostics in Kotlin as a follow-up.
- Tapping the placeholder's Recents entry produces `CallIntentReceivedEvent(handle: "invalid")`; integrators should treat that handle as non-actionable (the constant handle at least collapses Recents rows; the old random-UUID handles accumulated).
- `caller.id` is logged (existing `serverCallId` precedent); switching to presence/type-only is a one-liner if preferred.
- Swift verified with `swiftc -parse`; no test target exists. The example-server TS change needs a `bun`/flox environment for a machine check.
