### PR TITLE
fix(android): mute the hardware microphone on mute state changes

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
   <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />

--- a/android/src/main/java/expo/modules/callkittelecom/managers/CallAudioManager.kt
+++ b/android/src/main/java/expo/modules/callkittelecom/managers/CallAudioManager.kt
@@ -149,6 +149,8 @@ object CallAudioManager {
         DialtonePlayer.stop()
         CallKitTelecomLog.d(TAG) { "Deactivating audio session - calls: ${calls.size}" }
 
+        // isMicrophoneMute is process-wide and survives the call, so clear it here.
+        audioManager.isMicrophoneMute = false
         currentEndpoint = null
         currentAvailableEndpoints = emptyList()
         isActive = false
@@ -158,6 +160,13 @@ object CallAudioManager {
         val callInfos = calls.map { mapOf("id" to it.id.toString(), "status" to it.status.value) }
 
         CallEventEmitter.send(CallEvents.AUDIO_SESSION_DEACTIVATED, mapOf("calls" to callInfos))
+    }
+
+    /** Mutes or unmutes the hardware microphone input. */
+    fun setMicrophoneMute(muted: Boolean) {
+        if (!isInitialized) return
+
+        audioManager.isMicrophoneMute = muted
     }
 
     /** Requests endpoint change to speaker (`true`) or best non-speaker device (`false`). */

--- a/android/src/main/java/expo/modules/callkittelecom/managers/CallManager.kt
+++ b/android/src/main/java/expo/modules/callkittelecom/managers/CallManager.kt
@@ -598,6 +598,7 @@ class CallManager private constructor() {
     fun setMuted(id: UUID, muted: Boolean) {
         CallKitTelecomLog.d(TAG) { "Setting mute state - id: $id, muted: $muted" }
         CallStore.updateMuted(id, muted)
+        CallAudioManager.setMicrophoneMute(muted)
         CallEventEmitter.send(
             CallEvents.SET_MUTED_ACTION,
             mapOf("id" to id.toString(), "isMuted" to muted),
@@ -800,6 +801,7 @@ class CallManager private constructor() {
                 if (session.isMuted != muted) {
                     CallKitTelecomLog.d(TAG) { "Mute state changed - id: $id, isMuted: $muted" }
                     CallStore.updateMuted(id, muted)
+                    CallAudioManager.setMicrophoneMute(muted)
                     CallEventEmitter.send(
                         CallEvents.SET_MUTED_ACTION,
                         mapOf("id" to id.toString(), "isMuted" to muted),


### PR DESCRIPTION
## Problem

On Android, `setMuted` marks the call as muted and emits `onSetMutedAction`, but the microphone keeps recording. The docs tell the app to mute its own audio, and the usual way to do that is to turn off the local audio track:

```js
track.enabled = false;
```
On some WebRTC builds (@livekit/react-native-webrtc is one) that doesn't send silence, it stops sending audio altogether. The other side sees no audio arriving and hangs up. 

Here is a real call logs: after muting, outgoing packets stop completely.

```
tracks enabled=false
rtp IN packets=376  | OUT packets=339
rtp IN packets=1134 | OUT packets=339
rtp IN packets=1616 | OUT packets=339
```
### Fix

CallAudioManager gets a setMicrophoneMute method that mutes the real microphone. It runs in both places where the mute state changes:

- CallManager.setMuted — when the app asks for it
- the callScope.isMuted collector — when the user presses mute in the phone's call screen

Android keeps the microphone muted even after the call ends, so it is turned back on in onAudioDeactivated. Without that, hanging up while muted would leave the user muted in every other app.

MODIFY_AUDIO_SETTINGS is added to the library manifest because setMicrophoneMute needs it. It is a normal permission, so apps do not have to ask the user for it.

