### PR TITLE
feat(ios): make includesCallsInRecents configurable via a plugin prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ With custom ringtone and dialtone:
           "incomingCallTimeout": 45,
           "outgoingCallTimeout": 60,
           "fulfillAnswerCallTimeout": 30,
+          "includesCallsInRecents": true,
           "microphonePermission": "$(PRODUCT_NAME) needs the microphone to make calls."
         }
       ]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,7 @@ With custom ringtone and dialtone:
           "incomingCallTimeout": 45,
           "outgoingCallTimeout": 60,
           "fulfillAnswerCallTimeout": 30,
+          "includesCallsInRecents": true,
           "microphonePermission": "$(PRODUCT_NAME) needs the microphone to make calls."
         }
       ]
@@ -64,7 +65,7 @@ With custom ringtone and dialtone:
 }
 ```
 
-Files in `sounds` are copied into the iOS bundle and Android raw resources at prebuild time. The full prop type is `ExpoCallKitTelecomPluginProps` in `plugin/src/`.
+Files in `sounds` are copied into the iOS bundle and Android raw resources at prebuild time. Set `includesCallsInRecents: false` to keep calls out of the phone's Recents/call log (iOS — defaults to `true`; Android self-managed calls are never logged, so no flag is needed there). The full prop type is `ExpoCallKitTelecomPluginProps` in `plugin/src/`.
 
 ## Concepts
 

--- a/ios/Managers/CallManager.swift
+++ b/ios/Managers/CallManager.swift
@@ -59,7 +59,10 @@ class CallManager: NSObject {
     configuration.maximumCallGroups = 1
     configuration.maximumCallsPerCallGroup = 1
     configuration.supportedHandleTypes = [.phoneNumber, .generic]
-    configuration.includesCallsInRecents = true
+    configuration.includesCallsInRecents =
+      Bundle.main.object(
+        forInfoDictionaryKey: "ExpoCallKitTelecomIncludesCallsInRecents"
+      ) as? Bool ?? true
 
     if let ringtone = Bundle.main.object(
       forInfoDictionaryKey: "ExpoCallKitTelecomDefaultRingtone"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:plugin": "expo-module build plugin",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "test": "expo-module test",
+    "test": "expo-module test plugin",
     "typecheck": "tsc --noEmit && tsc --noEmit -p plugin",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",

--- a/plugin/jest.config.js
+++ b/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require("expo-module-scripts/jest-preset-plugin");

--- a/plugin/src/__tests__/withExpoCallKitTelecomIos.test.ts
+++ b/plugin/src/__tests__/withExpoCallKitTelecomIos.test.ts
@@ -1,0 +1,61 @@
+import type { ExpoConfig } from "expo/config";
+
+import type { ExpoCallKitTelecomPluginProps } from "../withExpoCallKitTelecom";
+import { withExpoCallKitTelecomIos } from "../withExpoCallKitTelecomIos";
+
+/**
+ * Applies the iOS plugin to a bare config and executes the registered
+ * Info.plist mod chain against an empty plist, returning the resulting
+ * plist entries. This exercises every `withInfoPlist` mod the plugin
+ * composes, without running a full prebuild.
+ */
+async function evaluateInfoPlist(
+  props: ExpoCallKitTelecomPluginProps,
+): Promise<Record<string, unknown>> {
+  let config: ExpoConfig & { mods?: any } = {
+    name: "test-app",
+    slug: "test-app",
+  };
+  config = withExpoCallKitTelecomIos(config, props) as typeof config;
+
+  const infoPlistMod = config.mods?.ios?.infoPlist;
+  expect(typeof infoPlistMod).toBe("function");
+
+  const result = await infoPlistMod({
+    ...config,
+    modResults: {},
+    modRequest: {
+      projectRoot: "/tmp/test-app",
+      platformProjectRoot: "/tmp/test-app/ios",
+      modName: "infoPlist",
+      platform: "ios",
+      introspect: true,
+    },
+    modRawConfig: { name: "test-app", slug: "test-app" },
+  });
+  return result.modResults;
+}
+
+describe("withExpoCallKitTelecomIos Info.plist configuration", () => {
+  it("defaults ExpoCallKitTelecomIncludesCallsInRecents to true when the prop is omitted", async () => {
+    const plist = await evaluateInfoPlist({});
+    expect(plist.ExpoCallKitTelecomIncludesCallsInRecents).toBe(true);
+  });
+
+  it("writes ExpoCallKitTelecomIncludesCallsInRecents=false when the prop is false", async () => {
+    const plist = await evaluateInfoPlist({ includesCallsInRecents: false });
+    expect(plist.ExpoCallKitTelecomIncludesCallsInRecents).toBe(false);
+  });
+
+  it("writes ExpoCallKitTelecomIncludesCallsInRecents=true when the prop is explicitly true", async () => {
+    const plist = await evaluateInfoPlist({ includesCallsInRecents: true });
+    expect(plist.ExpoCallKitTelecomIncludesCallsInRecents).toBe(true);
+  });
+
+  it("keeps writing the timeout defaults alongside the new key (chain intact)", async () => {
+    const plist = await evaluateInfoPlist({});
+    expect(plist.ExpoCallKitTelecomIncomingCallTimeout).toBe(45);
+    expect(plist.ExpoCallKitTelecomOutgoingCallTimeout).toBe(60);
+    expect(plist.ExpoCallKitTelecomFulfillAnswerCallTimeout).toBe(30);
+  });
+});

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -3,6 +3,9 @@ export const DEFAULT_INCOMING_CALL_TIMEOUT = 45;
 export const DEFAULT_OUTGOING_CALL_TIMEOUT = 60;
 export const DEFAULT_FULFILL_ANSWER_CALL_TIMEOUT = 30;
 
+// Whether completed calls appear in the phone's call history (Recents)
+export const DEFAULT_INCLUDES_CALLS_IN_RECENTS = true;
+
 /**
  * Action for the package-internal call-event broadcast (Android). The
  * `androidEventReceiver` plugin prop registers the manifest receiver for it.

--- a/plugin/src/withExpoCallKitTelecom.ts
+++ b/plugin/src/withExpoCallKitTelecom.ts
@@ -37,6 +37,13 @@ export type ExpoCallKitTelecomPluginProps = {
    */
   fulfillAnswerCallTimeout?: number;
   /**
+   * Whether completed calls appear in the phone's call history (Recents).
+   * Maps to CallKit's `CXProviderConfiguration.includesCallsInRecents`.
+   * @default true
+   * @platform ios
+   */
+  includesCallsInRecents?: boolean;
+  /**
    * Array of sound file paths (relative to project root) to include in the app.
    * These files will be copied into the iOS bundle and Android raw resources.
    * .wav recommended

--- a/plugin/src/withExpoCallKitTelecomIos.ts
+++ b/plugin/src/withExpoCallKitTelecomIos.ts
@@ -10,6 +10,7 @@ import { basename, resolve } from "path";
 
 import {
   DEFAULT_FULFILL_ANSWER_CALL_TIMEOUT,
+  DEFAULT_INCLUDES_CALLS_IN_RECENTS,
   DEFAULT_INCOMING_CALL_TIMEOUT,
   DEFAULT_OUTGOING_CALL_TIMEOUT,
 } from "./constants";
@@ -118,6 +119,20 @@ const withTimeouts: ConfigPlugin<{
       outgoingCallTimeout ?? DEFAULT_OUTGOING_CALL_TIMEOUT;
     config.modResults.ExpoCallKitTelecomFulfillAnswerCallTimeout =
       fulfillAnswerCallTimeout ?? DEFAULT_FULFILL_ANSWER_CALL_TIMEOUT;
+    return config;
+  });
+};
+
+/**
+ * Configures whether calls appear in the phone's call history (Recents).
+ */
+const withRecents: ConfigPlugin<{ includesCallsInRecents?: boolean }> = (
+  config,
+  { includesCallsInRecents },
+) => {
+  return withInfoPlist(config, (config) => {
+    config.modResults.ExpoCallKitTelecomIncludesCallsInRecents =
+      includesCallsInRecents ?? DEFAULT_INCLUDES_CALLS_IN_RECENTS;
     return config;
   });
 };
@@ -251,6 +266,7 @@ export const withExpoCallKitTelecomIos: ConfigPlugin<ExpoCallKitTelecomPluginPro
     incomingCallTimeout,
     outgoingCallTimeout,
     fulfillAnswerCallTimeout,
+    includesCallsInRecents,
     sounds,
     defaultRingtoneIos,
     defaultDialtone,
@@ -265,6 +281,7 @@ export const withExpoCallKitTelecomIos: ConfigPlugin<ExpoCallKitTelecomPluginPro
     outgoingCallTimeout,
     fulfillAnswerCallTimeout,
   });
+  config = withRecents(config, { includesCallsInRecents });
   config = withSounds(config, { sounds });
   config = withDefaultRingtone(config, {
     sounds,


### PR DESCRIPTION
Closes #34.

## Problem

`CXProviderConfiguration.includesCallsInRecents` is hardcoded to `true` in `ios/Managers/CallManager.swift`'s provider init. Apps presenting assistant/companion-style calls (rather than person-to-person telephony) may not want every interaction written into the phone's Recents/call log, and CallKit supports opting out — but the module currently gives integrators no way to reach the flag: it isn't a plugin prop, isn't runtime-settable, and isn't in the API reference.

(Android needs no equivalent change: the Core-Telecom path registers self-managed calls, which don't write the system call log unless an app opts in — and the module doesn't.)

## Change

A new optional plugin prop, following the module's existing prop → `ExpoCallKitTelecom*` Info.plist key → `Bundle.main` read pattern (same shape as the call-timeout props):

- `plugin/src/withExpoCallKitTelecom.ts` — `includesCallsInRecents?: boolean` on `ExpoCallKitTelecomPluginProps` (**default `true`** — behavior is unchanged for all current integrators).
- `plugin/src/constants.ts` — `DEFAULT_INCLUDES_CALLS_IN_RECENTS = true` alongside the other defaults.
- `plugin/src/withExpoCallKitTelecomIos.ts` — a `withRecents` mod writing `ExpoCallKitTelecomIncludesCallsInRecents`, composed with the other Info.plist mods.
- `ios/Managers/CallManager.swift` — the provider init reads the key with `as? Bool ?? true` (matching the timeout reads).
- `README.md` — the prop added to the plugin example.

## Testing

This adds the repo's **first plugin test**, wired per the expo-module-scripts docs:

- `plugin/jest.config.js` → `expo-module-scripts/jest-preset-plugin`, and the `test` script now runs `expo-module test plugin` (there were no module-level tests, so nothing is lost).
- `plugin/src/__tests__/withExpoCallKitTelecomIos.test.ts` — applies the iOS plugin to a bare config and executes the composed Info.plist mod chain: default-true when the prop is omitted, explicit false/true written through, and the existing timeout defaults still written (chain intact). **4/4 passing.**
- `typecheck` (app + plugin) clean; `build:plugin` clean (tests excluded from build output).
- Note: `bun run lint` currently exits 2 on an unmodified checkout of `main` as well (eslint tooling error, not findings) — pre-existing, untouched here.

## Context

Found while integrating the module (with LiveKit, per `docs/verified-against.md`) for an AI-assistant app where calls to the assistant shouldn't populate the phone's call history. Happy to adjust naming or approach to your preference.
