### PR TITLE
feat(android): withdraw a ringing call from an FCM push

### DIFF
--- a/android/src/main/java/expo/modules/callkittelecom/services/ExpoCallKitTelecomMessagingService.kt
+++ b/android/src/main/java/expo/modules/callkittelecom/services/ExpoCallKitTelecomMessagingService.kt
@@ -6,7 +6,9 @@ import android.util.Log
 import com.google.firebase.messaging.RemoteMessage
 import expo.modules.callkittelecom.managers.CallManager
 import expo.modules.callkittelecom.managers.VoIPPushManager
+import expo.modules.callkittelecom.models.CallEndedReason
 import expo.modules.callkittelecom.models.IncomingCallEvent
+import expo.modules.callkittelecom.store.CallStore
 import expo.modules.notifications.service.ExpoFirebaseMessagingService
 import java.util.concurrent.ConcurrentHashMap
 import org.json.JSONArray
@@ -22,6 +24,11 @@ import org.json.JSONObject
  * Wire format (matches example/server/lib/fcm.ts): data["messageType"] = "incomingCall"
  * data["incomingCall"] = JSON string of the IncomingCallEvent (camelCase). The snake_case envelope
  * (messageType/key "incoming_call") is also accepted for backwards compatibility.
+ *
+ * data["messageType"] = "callEnded" with data["callEnded"] = {"serverCallId": "..."} withdraws a
+ * call that is still ringing. On a killed app nothing else can: the ring is reported natively, so
+ * there is no JS observer to call reportCallEnded, and the phone would ring on until
+ * incomingCallTimeout even though the caller has hung up.
  */
 class ExpoCallKitTelecomMessagingService : ExpoFirebaseMessagingService() {
     companion object {
@@ -31,6 +38,8 @@ class ExpoCallKitTelecomMessagingService : ExpoFirebaseMessagingService() {
         // compatibility.
         private val MESSAGE_TYPE_INCOMING_CALL = setOf("incomingCall", "incoming_call")
         private val KEYS_INCOMING_CALL = listOf("incomingCall", "incoming_call")
+        private val MESSAGE_TYPE_CALL_ENDED = setOf("callEnded", "call_ended")
+        private val KEYS_CALL_ENDED = listOf("callEnded", "call_ended")
         private const val DEDUP_WINDOW_MS = 120_000L
 
         private val dedupeLock = Any()
@@ -39,6 +48,11 @@ class ExpoCallKitTelecomMessagingService : ExpoFirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         val data = message.data
+
+        if (data[KEY_MESSAGE_TYPE] in MESSAGE_TYPE_CALL_ENDED) {
+            Handler(Looper.getMainLooper()).post { processCallEnded(data) }
+            return
+        }
 
         // Try to parse as an incoming call payload.
         val eventMap = if (data.isNotEmpty()) parseIncomingCallEvent(data) else null
@@ -82,6 +96,28 @@ class ExpoCallKitTelecomMessagingService : ExpoFirebaseMessagingService() {
         } catch (error: Throwable) {
             Log.e(TAG, "Failed to process incoming call push: ${error.message}", error)
         }
+    }
+
+    /**
+     * Ends the session whose serverCallId matches, so a call the caller has abandoned stops
+     * ringing at once rather than running to the timeout.
+     */
+    private fun processCallEnded(data: Map<String, String>) {
+        val raw = KEYS_CALL_ENDED.firstNotNullOfOrNull { data[it] } ?: return
+        val serverCallId = runCatching { JSONObject(raw).optString("serverCallId") }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: return
+
+        CallManager.shared.initialize(applicationContext)
+        val session = CallStore.allSessions()
+            .firstOrNull { it.incomingCallEvent?.serverCallId == serverCallId }
+        if (session == null) {
+            Log.d(TAG, "No ringing call matches serverCallId $serverCallId")
+            return
+        }
+        CallManager.shared.reportCallEnded(session.id, CallEndedReason.REMOTE_ENDED)
+        Log.d(TAG, "Withdrew a ringing call from FCM payload")
     }
 
     private fun parseIncomingCallEvent(data: Map<String, String>): Map<String, Any?>? {

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -49,6 +49,28 @@ The broadcast carries two extras: `eventName` (the call event that couldn't reac
 
 A complete working setup ships in the example app: `example/client/` sets `androidEventReceiver` in `app.config.ts` and copies `plugins/CallEndedReceiver.kt` into the generated android project — see "Testing system → app paths" in the example README for how to exercise it.
 
+### Withdrawing a ringing call
+
+The reverse direction has the same problem. If the caller hangs up while the callee's phone is
+still ringing, a killed app has no way to act on it: the ring was reported natively, so there is no
+JS observer to call `reportCallEnded`, and the phone rings on until `incomingCallTimeout`.
+
+Send a second data message and the module ends the call natively:
+
+```json
+{
+  "messageType": "callEnded",
+  "callEnded": "{\"serverCallId\":\"call-123\"}"
+}
+```
+
+`serverCallId` is the one you set on the `IncomingCallEvent` when you started the call. The module
+looks up the matching session and reports it ended with reason `remoteEnded`, which is the same
+path `reportCallEnded` takes from JS. A `serverCallId` with no ringing session is ignored, so a
+withdrawal that arrives late, or for a call that was already answered elsewhere, does nothing.
+
+The example server sends it with `bun send-test-push.ts --end --serverCallId call-123`.
+
 ## VoIP push token types
 
 The VoIP push token type is reported as `"APNS_VOIP"` on iOS and `"FCM"` on Android — send both to your backend so it knows which transport to use.

--- a/example/server/lib/fcm.ts
+++ b/example/server/lib/fcm.ts
@@ -22,6 +22,32 @@ export async function sendFcm(
   event: IncomingCallEvent,
   config: FcmConfig,
 ): Promise<void> {
+  await send(config, {
+    messageType: "incomingCall",
+    incomingCall: JSON.stringify(event),
+  });
+  console.log("✓ FCM sent");
+}
+
+/**
+ * Withdraws a call that is still ringing, so a killed app stops ringing at
+ * once instead of waiting out incomingCallTimeout.
+ */
+export async function sendFcmCallEnded(
+  serverCallId: string,
+  config: FcmConfig,
+): Promise<void> {
+  await send(config, {
+    messageType: "callEnded",
+    callEnded: JSON.stringify({ serverCallId }),
+  });
+  console.log("✓ FCM call-ended sent");
+}
+
+async function send(
+  config: FcmConfig,
+  data: Record<string, string>,
+): Promise<void> {
   const raw = await readFile(config.keyPath, "utf8");
   let account: ServiceAccount;
   try {
@@ -74,10 +100,7 @@ export async function sendFcm(
       body: JSON.stringify({
         message: {
           token: config.deviceToken,
-          data: {
-            messageType: "incomingCall",
-            incomingCall: JSON.stringify(event),
-          },
+          data,
           android: { priority: "HIGH" },
         },
       }),
@@ -86,5 +109,4 @@ export async function sendFcm(
   if (!fcmRes.ok) {
     throw new Error(`FCM: ${fcmRes.status} ${await fcmRes.text()}`);
   }
-  console.log("✓ FCM sent");
 }

--- a/example/server/send-test-push.ts
+++ b/example/server/send-test-push.ts
@@ -14,6 +14,8 @@
  *   bun send-test-push.ts --display "Alice"
  *   bun send-test-push.ts --phoneNumber +14155551234   # E.164; lets the OS match a contact
  *   bun send-test-push.ts --video
+ *   bun send-test-push.ts --end --serverCallId call-123   # Android: stop a call
+ *                                                         # that is still ringing
  *   bun send-test-push.ts --metadata '{"declineToken":"abc"}'   # JSON object; rides into
  *                                                               # the killed-app call-ended
  *                                                               # broadcast on Android
@@ -40,7 +42,7 @@ import { join } from "node:path";
 import { sendApns } from "./lib/apns";
 import { apnsEnvSchema, fcmEnvSchema, parseEnv } from "./lib/env";
 import { buildEvent } from "./lib/event";
-import { sendFcm } from "./lib/fcm";
+import { sendFcm, sendFcmCallEnded } from "./lib/fcm";
 
 const APNS_KEY_PATH = join(import.meta.dir, "apns_key.p8");
 const FCM_KEY_PATH = join(import.meta.dir, "fcm_key.json");
@@ -78,6 +80,9 @@ const event = buildEvent({
   metadata: parseMetadata(arg("--metadata")),
 });
 
+// Withdraw a ringing call rather than start one. Android only: on iOS the
+// app is awake after a VoIP push and calls reportCallEnded itself.
+const endCall = flag("--end");
 const forceIos = flag("--ios");
 const forceAndroid = flag("--android");
 const usePrd = flag("--production");
@@ -104,11 +109,20 @@ async function runApns(): Promise<void> {
 
 async function runFcm(): Promise<void> {
   const env = parseEnv(fcmEnvSchema, "FCM");
-  await sendFcm(event, { keyPath: FCM_KEY_PATH, deviceToken: env.FCM_TOKEN });
+  const config = { keyPath: FCM_KEY_PATH, deviceToken: env.FCM_TOKEN };
+  if (endCall) {
+    await sendFcmCallEnded(event.serverCallId, config);
+    return;
+  }
+  await sendFcm(event, config);
 }
 
 async function main(): Promise<void> {
-  console.log("Sending IncomingCallEvent:", JSON.stringify(event, null, 2));
+  if (endCall) {
+    console.log("Withdrawing call:", event.serverCallId);
+  } else {
+    console.log("Sending IncomingCallEvent:", JSON.stringify(event, null, 2));
+  }
   const jobs: Promise<void>[] = [];
   if (want("ios")) jobs.push(runApns());
   if (want("android")) jobs.push(runFcm());


### PR DESCRIPTION
## The gap

`docs/platform-notes.md` covers the killed-app problem in the outbound direction, where a decline can't reach JS. #19 solved that with a broadcast. This is the same gap in the other direction: the server telling a killed phone that the caller hung up.

On a killed app the incoming call is reported natively and no React context starts. When the caller gives up, nothing can act on it. The withdrawal arrives as another FCM data message, `ExpoCallKitTelecomMessagingService` doesn't recognise it and hands it to `super`. There is no JS observer, since the app was woken natively and never started a runtime, and `reportCallEnded()` is only reachable from JS. The phone rings until `incomingCallTimeout` expires. At the 45 seconds we use, someone answering half a minute after the caller gave up picks up a call that no longer exists.

#24 was closed with the note that dismissing a call remotely is part of your own transport. That holds on iOS, where a VoIP push wakes the app and you call `reportCallEnded` yourself. It doesn't hold on Android, because the module is the registered `MESSAGING_EVENT` handler and `withFirebaseMessagingService` removes the app's own service with `tools:node="remove"`. App code never sees the message.

## What this adds

A second message type, laid out the same way as the existing one:

```
data["messageType"] = "callEnded"
data["callEnded"]   = {"serverCallId": "..."}
```

The service finds the session by `serverCallId` in `CallStore.allSessions()` and calls `CallManager.reportCallEnded(session.id, REMOTE_ENDED)`, which is the path `reportCallEnded` takes from JS. `call_ended` is accepted alongside `callEnded`, matching how `incoming_call` works today.

## Why this shape

There is no new API surface. No plugin props, no JS API, no new constants past the message-type strings, and it reuses the `serverCallId` the app already supplies when it starts the call.

Nothing changes for existing apps. A message without `messageType: "callEnded"` follows exactly the path it follows today. A `serverCallId` with no ringing session is logged and ignored, so a withdrawal arriving late, or for a call already answered elsewhere, does nothing.

## Verified

Samsung Galaxy S21+ on Android 15, app force-killed. Ring, then withdraw:

```
D ExpoCallKitTelecom.FCM: Reported incoming call from FCM payload
D ExpoCallKitTelecom.FCM: Withdrew a ringing call from FCM payload
```

Telecom's ringing count goes to 0 within about a second instead of running the full 45. I've been carrying this as a patch-package patch against 0.4.0 in a production app.

## Environment

`expo-callkit-telecom` 0.4.0, Expo SDK 55.0.31, React Native 0.83.10, Android 15. Media transport is react-native-webrtc 124.0.7 on Android only; the module is excluded from Apple autolinking in that app, since the iOS half needs LiveKit's WebRTC fork.
